### PR TITLE
Add EXR environment map and better framing for objects

### DIFF
--- a/src/cache-indices.ts
+++ b/src/cache-indices.ts
@@ -12,7 +12,7 @@ export default function cacheIndices(
     }
 
     mesh.primitives.forEach((primitive: any, primitiveIndex: number) => {
-      if (!primitive.extensions && !primitive.extensions[EXTENSION_NAME]) {
+      if (!primitive.extensions || !primitive.extensions[EXTENSION_NAME]) {
         return;
       }
 


### PR DESCRIPTION
- Adds shopify_foyer EXR for a test environment map (also used as the background)
- Fixes a bug when loading non-variant glTFs
- Adds frameObject method for scaling objects properly inside the view frustum.